### PR TITLE
chore: update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "dependencyDashboard": false,
   "dependencyDashboardTitle": "Dependency Dashboard",
   "rangeStrategy": "bump",
+  "ignoreTests": true,
   "prConcurrentLimit": 7,
   "schedule": ["* 5-6 * * 7"],
   "lockFileMaintenance": {


### PR DESCRIPTION
Allow to automerge patch versions of dependencies without running checks.