### PR TITLE
chore(ci): migrate release workflow from semantic-release to release-it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,30 @@ jobs:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 24.14.0
-          cache: "npm"
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Quality check
-        run: npm run biome:check
+        run: pnpm run biome:check
 
       - name: Execute release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REL_TOKEN }}
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
           LEFTHOOK: 0
-        run: npx semantic-release
+        run: pnpm run release -- --ci

--- a/.release-it.json
+++ b/.release-it.json
@@ -50,7 +50,9 @@
           }
         ]
       },
-      "infile": "CHANGELOG.md"
+      "infile": "CHANGELOG.md",
+      "ignoreRecommendedBump": false,
+      "strictSemVer": true
     }
   }
 }


### PR DESCRIPTION
## Changes

Migrates the release workflow to match the actual tooling used in the project (`release-it` instead of `semantic-release`).

### `release.yml`
- Add `pnpm/action-setup` step before Node.js setup
- Switch `cache: "npm"` → `cache: "pnpm"`
- Replace `npm ci` → `pnpm install --frozen-lockfile`
- Replace `npm run biome:check` → `pnpm run biome:check`
- Replace `npx semantic-release` → `pnpm run release -- --ci`

### `.release-it.json`
- Add `ignoreRecommendedBump: false` and `strictSemVer: true` to conventional-changelog plugin config

### Release flow confirmed
1. `@release-it/conventional-changelog` — bumps version, updates `CHANGELOG.md`
2. git commit + tag + push
3. `after:git:release` hook — builds `.vsix` via `@vscode/vsce package`
4. GitHub release — created with `.vsix` attached as asset
5. `after:release` hook — publishes to VS Code Marketplace via `@vscode/vsce publish`