### PR TITLE
chore: add vsce build, pack, and publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     ]
   },
   "scripts": {
+    "vsce:pack": "vsce pack -o ./",
+    "vsce:build": "vsce pack -o ./",
+    "vsce:publish": "vsce publish",
     "biome:write": "biome format --write .",
     "biome:check": "biome check .",
     "prepare": "lefthook install"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  '@vscode/vsce-sign': true
+  keytar: true
+  lefthook: true
 onlyBuiltDependencies:
   - '@vscode/vsce-sign'
   - keytar


### PR DESCRIPTION
Added `vsce:pack`, `vsce:build`, and `vsce:publish` scripts to facilitate packaging and publishing of the extension. Updated `pnpm-workspace.yaml` to include build configurations for `@vscode/vsce-sign`, `keytar`, and `lefthook`.