### PR TITLE
chore(vscode): add settings for biome formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "prettier.enable": false,
+  "editor.defaultFormatter": "biomejs.biome",
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}


### PR DESCRIPTION
Added `.vscode/settings.json` to configure the default code formatter for various file types to `biomejs.biome` and disabled Prettier formatting to prevent conflicts with the new setup. This configuration applies to TypeScript, JavaScript, TypeScript React, JavaScript React, JSON, and CSS file types.