### PR TITLE
chore: add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo
+
+* @rapaglaz


### PR DESCRIPTION
Added a `CODEOWNERS` file to define the default owner for the repository.