### PR TITLE
feat: add theme to Open VSX Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,6 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
           LEFTHOOK: 0
         run: pnpm exec semantic-release

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Cool blue-grey UI, pastel syntax highlighting, low visual noise.
 
 [VS Code Marketplace →](https://marketplace.visualstudio.com/items?itemName=own-themes.own-dark-001)
 
+[Open VSX Registry →](https://open-vsx.org/extension/own-themes/own-dark-001)
+
 ## Screenshots
 
 ##### TypeScript

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "scripts": {
     "vsce:pack": "vsce pack -o ./",
-    "vsce:publish": "vsce publish",
     "format:write": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "lefthook install"
@@ -58,6 +57,7 @@
     "conventional-changelog-conventionalcommits": "9.3.1",
     "lefthook": "2.1.12",
     "lint-staged": "17.4.1",
+    "ovsx": "1.1.1",
     "prettier": "3.9.6",
     "semantic-release": "25.0.9",
     "semantic-release-vsce": "6.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lint-staged:
         specifier: 17.4.1
         version: 17.4.1
+      ovsx:
+        specifier: 1.1.1
+        version: 1.1.1(@types/node@26.4.0)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       prettier:
         specifier: 3.9.6
         version: 3.9.6


### PR DESCRIPTION
Added a link to the `Open VSX Registry` in the `README.md` to provide users with direct access to the theme. 

Updated the `release.yml` workflow to include the `OVSX_PAT` environment variable for publishing to the Open VSX Registry. 

Added the `ovsx` package as a dependency in `package.json` and updated `pnpm-lock.yaml` accordingly.